### PR TITLE
docs: update picgo-plugin-bilibili

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | [picgo-plugin-smms-user](https://github.com/xlzy520/picgo-plugin-smms-user.git) | An **uploader** for registered user of SM.MS.                | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-gitlab](https://github.com/bugwz/picgo-plugin-gitlab) | An **uploader** for GitLab.                                  | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-gitlab-files](https://github.com/D-W-X/picgo-plugin-gitlab-files) | An **uploader** for GitLab.Every file make a pull request.   | :white_check_mark: | :white_check_mark: |
-| [picgo-plugin-bilibili](https://www.npmjs.com/package/picgo-plugin-bilibili) | An **uploader** for Bilibli.                                 | :white_check_mark: | :white_check_mark: |
+| [picgo-plugin-bilibili](https://github.com/xlzy520/picgo-plugin-bilibili) | An **uploader** for Bilibli.                                 | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-gitee](https://github.com/zhanghuid/picgo-plugin-gitee) | An **uploader** for Gitee.                                   | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-gitee-uploader](https://github.com/lizhuangs/picgo-plugin-gitee-uploader#readme) | An **uploader** for Gitee.                                   | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-nextcloud-uploader](https://github.com/jiajiajia343434/picgo-plugin-nextcloud-uploader) | An **uploader** for Nextcloud.                               | :white_check_mark: | :white_check_mark: |


### PR DESCRIPTION
两年前没成功完成的插件，前几天在网友的要求继续尝试，终于还是实现了，现在把之前的插件地址由npm改成GitHub