### PR TITLE
add plugin lankong

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 | [picgo-plugin-imgtp](https://github.com/Redns/picgo-plugin-imgtp) | An **uploader** for [ImgTP](https://imgtp.com/)              | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-imagebed](https://github.com/Redns/picgo-plugin-imagebed) | An **uploader** for [ImageBed](https://github.com/Redns/ImageBed) | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-mmwiki](https://github.com/wowtalon/picgo-plugin-mmwiki) | An **uploader** for [mm-wiki](https://github.com/phachon/mm-wiki) | :white_check_mark: | :white_check_mark: |
-| [picgo-plugin-imgkb](https://github.com/hellodk34/picgo-plugin-imgkb) | An **uploader** for [imgkb.com](https://imgkb.com/) | :white_check_mark: | :white_check_mark: |
+| [picgo-plugin-lankong](https://github.com/hellodk34/picgo-plugin-lankong) | An **uploader** for [兰空图床 Lsky Pro](https://github.com/lsky-org/lsky-pro) 支持 V1 和 V2 | :white_check_mark: | :white_check_mark: |
 
 ## :hammer_and_wrench: Plugin for Other APPs
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 | [picgo-plugin-imgtp](https://github.com/Redns/picgo-plugin-imgtp) | An **uploader** for [ImgTP](https://imgtp.com/)              | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-imagebed](https://github.com/Redns/picgo-plugin-imagebed) | An **uploader** for [ImageBed](https://github.com/Redns/ImageBed) | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-mmwiki](https://github.com/wowtalon/picgo-plugin-mmwiki) | An **uploader** for [mm-wiki](https://github.com/phachon/mm-wiki) | :white_check_mark: | :white_check_mark: |
+| [picgo-plugin-imgkb](https://github.com/hellodk34/picgo-plugin-imgkb) | An **uploader** for [imgkb.com](https://imgkb.com/) | :white_check_mark: | :white_check_mark: |
 
 ## :hammer_and_wrench: Plugin for Other APPs
 


### PR DESCRIPTION
兰空图床 V2 版本于 2022 年 3 月发布，请求合并。