### PR TITLE
add picgo-plugin-oss-outside-url plugin for PicGo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 | [picgo-plugin-ipfs](https://github.com/KANIKIG/picgo-plugin-ipfs) | An **uploader** for IPFS. | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-alist](https://github.com/jinzhi0123/picgo-plugin-alist) | An **uploader** for Alist 在picgo把alist作为图床 | :white_check_mark: | :white_check_mark: |
 | [picgo-plugin-light-picture](https://github.com/ColdeZhang/picgo-plugin-light-picture) | An **uploader** for Light Picture 适用于Light Picture图床 | :x: | :white_check_mark: |
+| [picgo-plugin-oss-outside-url](https://github.com/caohongliang92/picgo-plugin-oss-outside-url) | A plugin for PicGo to get oss outside url 用于获取OSS私有空间资源外链的PicGo插件，支持阿里云OSS、腾讯云COS、七牛云Kodo | :white_check_mark: | :white_check_mark: |
 <!-- | [picgo-plugin-superbed](https://github.com/MoyuScript/picgo-plugin-superbed) | An **uploader** for [Superbed（聚合图床）](https://www.superbed.cn/) | :white_check_mark: | :white_check_mark: | -->
 
 ## :hammer_and_wrench: Plugin for Other APPs


### PR DESCRIPTION
A plugin for PicGo to get oss outside url
用于获取OSS私有空间资源外链的PicGo插件，支持阿里云OSS、腾讯云COS、七牛云Kodo